### PR TITLE
Fix cargo nightly install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ There is a demand to recompile every time while customizing, but you change your
 ```bash
 git clone https://github.com/Xeoeen/powerline-rust
 cd powerline-rust
-cargo +nightly install
+cargo +nightly install --path .
 ```
 ## Setting up shell
 #### Make sure you have executable in `$PATH`


### PR DESCRIPTION
Running `cargo +nightly install` results in:
```
error: Using `cargo install` to install the binaries for the package in current working directory is no longer supported, use `cargo install --path .` instead. Use `cargo build` if you want to simply build the package.
```

This PR adds the replaces the old install instructions with the appropriate command in the README.