### PR TITLE
Add exit_code module

### DIFF
--- a/src/bin/powerline.rs
+++ b/src/bin/powerline.rs
@@ -11,6 +11,7 @@ fn main() -> powerline::R<()> {
 	prompt.add_module(Git::<SimpleTheme>::new())?;
 	prompt.add_module(ReadOnly::<SimpleTheme>::new())?;
 	prompt.add_module(Cmd::<SimpleTheme>::new())?;
+	// prompt.add_module(ExitCode::<SimpleTheme>::new())?;
 
 	println!("{}", prompt);
 	Ok(())

--- a/src/modules/exit_code.rs
+++ b/src/modules/exit_code.rs
@@ -1,0 +1,31 @@
+use std::{env, marker::PhantomData};
+
+use super::Module;
+use crate::{powerline::Segment, terminal::Color, R};
+
+pub struct ExitCode<S: ExitCodeScheme> {
+	scheme: PhantomData<S>,
+}
+
+pub trait ExitCodeScheme {
+	const EXIT_CODE_BG: Color;
+	const EXIT_CODE_FG: Color;
+}
+
+impl<S: ExitCodeScheme> ExitCode<S> {
+	pub fn new() -> ExitCode<S> {
+		ExitCode { scheme: PhantomData }
+	}
+}
+
+impl<S: ExitCodeScheme> Module for ExitCode<S> {
+	fn append_segments(&mut self, segments: &mut Vec<Segment>) -> R<()> {
+		let exit_code = env::args().nth(1).unwrap_or("1".to_string());
+		if exit_code != "0" {
+			let (fg, bg) = (S::EXIT_CODE_FG, S::EXIT_CODE_BG);
+			segments.push(Segment::simple(format!(" {} ", exit_code), fg, bg));
+		}
+
+		Ok(())
+	}
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -2,6 +2,7 @@ use crate::{powerline::Segment, R};
 
 mod cmd;
 mod cwd;
+mod exit_code;
 mod git;
 mod host;
 mod readonly;
@@ -9,6 +10,7 @@ mod user;
 
 pub use cmd::{Cmd, CmdScheme};
 pub use cwd::{Cwd, CwdScheme};
+pub use exit_code::{ExitCode, ExitCodeScheme};
 pub use git::{Git, GitScheme};
 pub use host::{Host, HostScheme};
 pub use readonly::{ReadOnly, ReadOnlyScheme};

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -19,6 +19,11 @@ impl CwdScheme for SimpleTheme {
 	const SEPARATOR_FG: Color = Color(244);
 }
 
+impl ExitCodeScheme for SimpleTheme {
+	const EXIT_CODE_BG: Color = Color(161);
+	const EXIT_CODE_FG: Color = Color(15);
+}
+
 impl UserScheme for SimpleTheme {
 	const USERNAME_BG: Color = Color(240);
 	const USERNAME_FG: Color = Color(250);


### PR DESCRIPTION
This PR adds `exit_code` module that explicitly shows previous exit status value.

BTW I first thought this module was also missing from original powerline, but later noticed `cmd` can also show alert color, so maybe this PR might not be so interesting.
(I will send PR anyway)